### PR TITLE
Update iOS 16 availability check for Xcode 15

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/SkadnParametersManager.swift
+++ b/PrebidMobile/PrebidMobileRendering/SkadnParametersManager.swift
@@ -55,7 +55,7 @@ public class SkadnParametersManager: NSObject {
             }
             
             // For SKAdNetwork 4.0 add sourceidentifier that replaces campaign
-            if #available(iOS 16.0, *) {
+            if #available(iOS 16.1, *) {
                 if let sourceidentifier = skadnInfo.sourceidentifier, let sourceidentifierInteger = Int(sourceidentifier) {
                     imp.sourceIdentifier = NSNumber(value: sourceidentifierInteger)
                 }
@@ -86,7 +86,7 @@ public class SkadnParametersManager: NSObject {
                     productParams[SKStoreProductParameterAdNetworkCampaignIdentifier] = campaign
                 }
                 
-                if #available(iOS 16.0, *) {
+                if #available(iOS 16.1, *) {
                     if let sourceIdentifier = skadnInfo.sourceidentifier, let sourceidentifierInteger = Int(sourceIdentifier) {
                         productParams[SKStoreProductParameterAdNetworkSourceIdentifier] = NSNumber(value: sourceidentifierInteger)
                     }


### PR DESCRIPTION
This change is needed so the Ozone SDK compiles with latest Xcode 15.